### PR TITLE
Updating Quickstart-Android 

### DIFF
--- a/quickstart-java/app/build.gradle
+++ b/quickstart-java/app/build.gradle
@@ -2,10 +2,10 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.google.gms.google-services'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     defaultConfig {
         applicationId "com.hypertrack.quickstart.android.github"
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion 30
         versionCode 1
         versionName "1.0"
@@ -32,7 +32,7 @@ dependencies {
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
 
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation 'com.hypertrack:hypertrack:5.3.0'
+    implementation 'com.hypertrack:hypertrack:6.3.0'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/quickstart-java/app/src/main/java/com/hypertrack/quickstart/MainActivity.java
+++ b/quickstart-java/app/src/main/java/com/hypertrack/quickstart/MainActivity.java
@@ -37,6 +37,14 @@ public class MainActivity extends AppCompatActivity implements TrackingStateObse
         deviceId.setText(sdkInstance.getDeviceID());
         Log.d(TAG, "device id is " + sdkInstance.getDeviceID());
 
+        trackingStatusLabel.setOnClickListener(view -> {
+            if (sdkInstance.isRunning()) {
+                sdkInstance.stop();
+            } else {
+                sdkInstance.start();
+            }
+        });
+
     }
 
     @Override

--- a/quickstart-kotlin/app/build.gradle
+++ b/quickstart-kotlin/app/build.gradle
@@ -28,7 +28,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.hypertrack:hypertrack:6.1.4'
+    implementation 'com.hypertrack:hypertrack:6.3.0'
 
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'


### PR DESCRIPTION
Update details:
- Updating SDK version to 6.3.0
- Adding click listener in quickstart-java
- Aligning compile and min SDK version between java and kotlin repo's gradle files.